### PR TITLE
[hotfix/getAttrs] returning all atributes on no match

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -28,13 +28,14 @@ const _toTruthyStringArray = (input) => {
 
 
 /**
- * Retrieves attribute nodes or their literal values from a given element path
+ * Retrieves attribute nodes from a given element path.
+ * If no `wantedAttrs` passed, all attributes will be returned.
  * @param   {object}            node            Valid element node
  * @param   {(string|string[])} [wantedAttrs]   One or more attribute names to match
- * @returns {any[]|null}
+ * @returns {any[]}
  */
 export const getAttrs = (node, wantedAttrs) => {
-  let output = null;
+  let output = [];
 
   if(isElement(node)){
     const allAttrs = node.openingElement.attributes || [];
@@ -50,9 +51,9 @@ export const getAttrs = (node, wantedAttrs) => {
           }
         });
       }
-    }
 
-    output = filteredAttrs.length ? filteredAttrs : allAttrs;
+      output = wantedAttrsAsArray.length ? filteredAttrs : allAttrs;
+    }
   }
 
   return output;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jscodeshaft",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "jscodeshaft",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Collection of more or less primitive helpers and abstractions for JSCodeShift, build for design system migrations and upgrades.",
   "repository": "https://github.com/criography/jscodeshaft",
-  "main": "lib/index.js",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "lib/index.js",
   "scripts": {
-    "start": "jscodeshift -t ./sandbox/transformer.js sandbox --parser=babel",
+    "start": "jscodeshift -t ./sandbox/transformer.js sandbox/src --parser=babel",
     "rollup": "rollup ./lib/index.js --file ./dist/index.js --format cjs",
-    "prepublish": "npm run rollup && npm run version",
+    "prepublish": "npm run rollup && npm version",
     "lint:dev": "eslint -c .eslintrc.dev --quiet --ext .js 'lib/'",
     "lint:dev:fix": "eslint -c .eslintrc.dev --quiet --ext .jsx --ext .js --fix 'lib/'"
   },
@@ -24,9 +24,15 @@
     "rollup": "2.10.0"
   },
   "author": {
-    "name" : "criography",
-    "url" : "http://criography.com/"
+    "name": "criography",
+    "url": "http://criography.com/"
   },
   "license": "MIT",
-  "keywords": ["jscodeshift", "design system", "codemod", "code migration", "refactor"]
+  "keywords": [
+    "jscodeshift",
+    "design system",
+    "codemod",
+    "code migration",
+    "refactor"
+  ]
 }


### PR DESCRIPTION
### Fixes
1. The `getAttrs` helper should now return an empty array on no matches found
1. Swapped `main` and `module` values in `packag.json`